### PR TITLE
MicropolisJ: Fix build option no longer supported

### DIFF
--- a/micropolis-java/build.xml
+++ b/micropolis-java/build.xml
@@ -77,7 +77,7 @@
        classpathref="build-classpath"
 	includeantruntime="false"
 	debug="true" debuglevel="lines,vars,source"
-	source="1.6" target="1.6"
+	source="17" target="17"
        >
 	<compilerarg value="-Xlint:unchecked" />
 	<compilerarg value="-Xlint:deprecation" />


### PR DESCRIPTION
[javac] error: Source option 6 is no longer supported. Use 7 or later.
[javac] error: Target option 6 is no longer supported. Use 7 or later.